### PR TITLE
Add unique Name for Hotkeys

### DIFF
--- a/downstream-keyer.cpp
+++ b/downstream-keyer.cpp
@@ -197,11 +197,13 @@ void DownstreamKeyer::on_actionAddScene_triggered()
 		std::string enable_hotkey = obs_module_text("EnableDSK");
 		enable_hotkey += " ";
 		enable_hotkey += QT_TO_UTF8(objectName());
+		enable_hotkey_name = 'DSK.' + sceneName + '.enable'
 		std::string disable_hotkey = obs_module_text("DisableDSK");
 		disable_hotkey += " ";
 		disable_hotkey += QT_TO_UTF8(objectName());
+		disable_hotkey_name = 'DSK.' + sceneName + '.disable'
 		uint64_t h = obs_hotkey_pair_register_source(
-			scene, enable_hotkey.c_str(), enable_hotkey.c_str(),
+			scene, enable_hotkey_name.c_str(), disable_hotkey_name.c_str(),
 			disable_hotkey.c_str(), disable_hotkey.c_str(),
 			enable_DSK_hotkey, disable_DSK_hotkey, this, this);
 


### PR DESCRIPTION
When using the DSK with e.g. OBS-Websocket you can identify the Hotkey. Previously it always was "_Show / Hide_ on DSK **x**" now it is "DSK **x**.**sceneName**._enable/disable_", while maintaining the previous style in the OBS settings (Hotkey Description). Therefore making remote controlling the DSK possible