### PR TITLE
row number parameter for AddScene

### DIFF
--- a/downstream-keyer-dock.cpp
+++ b/downstream-keyer-dock.cpp
@@ -588,13 +588,13 @@ bool DownstreamKeyerDock::SwitchDSK(QString dskName, QString sceneName)
 	return false;
 }
 
-bool DownstreamKeyerDock::AddScene(QString dskName, QString sceneName)
+bool DownstreamKeyerDock::AddScene(QString dskName, QString sceneName, int insertBeforeRow)
 {
 	const int count = tabs->count();
 	for (int i = 0; i < count; i++) {
 		auto w = dynamic_cast<DownstreamKeyer *>(tabs->widget(i));
 		if (w->objectName() == dskName) {
-			if (w->AddScene(sceneName)) {
+			if (w->AddScene(sceneName, insertBeforeRow)) {
 				return true;
 			}
 		}
@@ -804,6 +804,7 @@ void DownstreamKeyerDock::add_scene(obs_data_t *request_data, obs_data_t *respon
 	auto dsk = _dsks[viewName];
 	const char *dsk_name = obs_data_get_string(request_data, "dsk_name");
 	const char *scene_name = obs_data_get_string(request_data, "scene");
+	int insertBeforeRow = obs_data_get_int(request_data, "insertBeforeRow");
 	if (!scene_name || !strlen(scene_name)) {
 		obs_data_set_string(response_data, "error", "'scene' not set");
 		obs_data_set_bool(response_data, "success", false);
@@ -815,7 +816,13 @@ void DownstreamKeyerDock::add_scene(obs_data_t *request_data, obs_data_t *respon
 		obs_data_set_bool(response_data, "success", false);
 		return;
 	}
-	obs_data_set_bool(response_data, "success", dsk->AddScene(QString::fromUtf8(dsk_name), QString::fromUtf8(scene_name)));
+
+
+	obs_data_set_bool(response_data, "success",
+			  dsk->AddScene(QString::fromUtf8(dsk_name),
+					QString::fromUtf8(scene_name),
+					insertBeforeRow)
+	);
 }
 
 void DownstreamKeyerDock::remove_scene(obs_data_t *request_data, obs_data_t *response_data, void *param)

--- a/downstream-keyer-dock.hpp
+++ b/downstream-keyer-dock.hpp
@@ -24,7 +24,7 @@ private:
 	void Save(obs_data_t *data);
 	void Load(obs_data_t *data);
 	bool SwitchDSK(QString dskName, QString sceneName);
-	bool AddScene(QString dskName, QString sceneName);
+	bool AddScene(QString dskName, QString sceneName, int insertBeforeRow);
 	bool RemoveScene(QString dskName, QString sceneName);
 	bool SetTie(QString dskName, bool tie);
 	bool SetTransition(const QString &chars, const char *transition, int duration, transitionType tt);

--- a/downstream-keyer.cpp
+++ b/downstream-keyer.cpp
@@ -220,7 +220,8 @@ void DownstreamKeyer::on_actionAddScene_triggered()
 		return;
 	auto sceneName = QT_UTF8(obs_source_get_name(scene));
 	if (scenesList->findItems(sceneName, Qt::MatchFixedString).count() == 0) {
-		add_scene(sceneName, scene);
+		const auto currentRow = scenesList->currentRow();
+		add_scene(sceneName, scene, currentRow);
 	}
 
 	obs_source_release(scene);
@@ -834,10 +835,14 @@ bool DownstreamKeyer::SwitchToScene(QString scene_name)
 	return false;
 }
 
-void DownstreamKeyer::add_scene(QString scene_name, obs_source_t *s)
+void DownstreamKeyer::add_scene(QString scene_name, obs_source_t *s, int insertBeforeRow)
 {
 	const auto item = new QListWidgetItem(scene_name);
-	scenesList->addItem(item);
+	int scenesListCount = scenesList->count();
+	if ((insertBeforeRow > scenesListCount) || (insertBeforeRow < 0)) {
+		insertBeforeRow = scenesListCount;
+	}
+	scenesList->insertItem(insertBeforeRow, item);
 
 	std::string enable_hotkey = obs_module_text("EnableDSK");
 	enable_hotkey += " ";
@@ -853,7 +858,7 @@ void DownstreamKeyer::add_scene(QString scene_name, obs_source_t *s)
 	}
 }
 
-bool DownstreamKeyer::AddScene(QString scene_name)
+bool DownstreamKeyer::AddScene(QString scene_name, int insertBeforeRow)
 {
 	if (scene_name.isEmpty()) {
 		return false;
@@ -865,8 +870,7 @@ bool DownstreamKeyer::AddScene(QString scene_name)
 	auto name = nameUtf8.constData();
 	auto s = obs_get_source_by_name(name);
 	if (obs_source_is_scene(s)) {
-
-		add_scene(scene_name, s);
+		add_scene(scene_name, s, insertBeforeRow);
 		obs_source_release(s);
 		return true;
 	}

--- a/downstream-keyer.hpp
+++ b/downstream-keyer.hpp
@@ -91,8 +91,8 @@ public:
 	void RemoveExcludeScene(const char *scene_name);
 	bool IsSceneExcluded(const char *scene_name);
 	bool SwitchToScene(QString scene_name);
-	void add_scene(QString scene_name, obs_source_t *s);
-	bool AddScene(QString scene_name);
+	void add_scene(QString scene_name, obs_source_t *s, int insertBeforeRow);
+	bool AddScene(QString scene_name, int insertBeforeRow);
 	bool RemoveScene(QString scene_name);
 	void SetTie(bool tie);
 	void SetOutputChannel(int outputChannel);


### PR DESCRIPTION
- Added parameters to AddScene-related functions to support adding a Scene to a DSK at a specific index.
- - I had wanted this to be an optional parameter (defaulting to -1), however I found that websocket was not handling this correctly. I had to hardcode -1 into my script, so clearly the default behavior wasn't working.
- Pressing the Add Scene button on the front end UI while a scene is selected in the DSK will put the scene prior to the selected scene. If none selected, then scene is added to the end of the list (as usual)
- - I had users complaining about dragging a scene from the end up to where they wanted it. This solves that, but it will break existing websocket requests because they have to specify the row number (-1) now.
- - An argument could be made that Add Scene should put scenes directly below (instead of before) the selected scene.  This would align with Scene List behavior. However, it then becomes impossible to add a scene at the top of a list (unless that becomes the default, which would be counter-intuitive)
